### PR TITLE
Fix logging out from the X11 sessions when on x11-user

### DIFF
--- a/src/helper-x11/xorguserhelper.cpp
+++ b/src/helper-x11/xorguserhelper.cpp
@@ -268,6 +268,13 @@ bool XOrgUserHelper::startClient()
     if (!startProcess(m_clientCmd, env, &m_clientProcess))
         return false;
 
+    connect(m_clientProcess, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+        this, [this] (int code, QProcess::ExitStatus status) {
+        qInfo() << "Session finished with code:" << code << status;
+        m_serverProcess->terminate();
+        QCoreApplication::instance()->quit();
+    });
+
     return true;
 }
 


### PR DESCRIPTION
We need to stop the X server and quit when the session exits. Otherwise
it stays on forever.