### PR TITLE
Only set QT_IM_MODULE if we have a value to give

### DIFF
--- a/src/greeter/GreeterApp.cpp
+++ b/src/greeter/GreeterApp.cpp
@@ -340,7 +340,9 @@ int main(int argc, char **argv)
     qputenv("KDE_DEBUG", "1");
 
     // Qt IM module
-    qputenv("QT_IM_MODULE", SDDM::mainConfig.InputMethod.get().toLocal8Bit().constData());
+    if (!SDDM::mainConfig.InputMethod.get().isEmpty()) {
+        qputenv("QT_IM_MODULE", SDDM::mainConfig.InputMethod.get().toLocal8Bit().constData());
+    }
 
     QGuiApplication app(argc, argv);
 


### PR DESCRIPTION
This allows us to have it unset on Wayland so Qt defaults to text input
and the compositor can treat it as a normal application and show its
virtual keyboard infrastructure.